### PR TITLE
add AUR installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ sudo pipx ensurepath --global # optional to allow pipx actions with --global arg
 - Arch:
 
 ```
+yay -S terminal-rain-lightning
+```
+
+```
 sudo pacman -S python-pipx
 pipx ensurepath
 sudo pipx ensurepath --global # optional to allow pipx actions with --global argument


### PR DESCRIPTION
I have published the package on the [Arch User Repository (AUR)](https://aur.archlinux.org/packages/terminal-rain-lightning) and it appears that users have already started to use it. 

Adding the AUR instruction to the README would be beneficial for the community.

Thank you for considering this update!